### PR TITLE
fix typo and add keyword assembly

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   },
   "keywords": [
     "javascript",
-    "lanuage"
+    "assembly",
+    "language"
   ],
   "dependencies": {
     "minimist": "~0.0.8",


### PR DESCRIPTION
- typo `language`
- keyword `assembly`
